### PR TITLE
Init SusaPad Software Insider

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -8,12 +8,26 @@
 
 *SusaPad Software* es el software usado para configurar *SusaPad*/[*MiniPad*][minipad].
 
-> **Note**: *SusaPad Software* hace referencia al proyecto en si mismo,
+> **Note**: *SusaPad Software* hace referencia al [SusaPad Software][software],
 > el no es el mismo que *SusaPad*, cuyo es un *keypad* (hardware).
 
+> **Note**: Este no está disponible para 
+> todas las versiones del *SusaPad*/*MiniPad*
+>
+> Por favor, leeas la [Sección de Compatibilidad](#compatibilidad)
+> para más información.
+
 [minipad]: https://github.com/minipadKB
+[software]: https://github.com/susapad/software
 
 ## Guía del usuario
+
+### Compatibilidad
+
+Este no está disponible para todas las versiones del *SusaPad*
+desde que este software fue diseñado solo para el *Insider Edition*,
+cuyo usa *Arduino* en vez de *Raspberry*
+y el [antigo firmware del *MiniPad*][old-firmware] en vez del más reciente.
 
 ### Instalación
 
@@ -28,7 +42,7 @@ Por favor, leas cuidadosamiente [nosa Issue fijada][issue-1]
 y asegúrase de saber sobre las
 [Pautas de la Comunidad de GitHub][gh-rules].
 
-[issue-1]: https://github.com/susapad/software/issues/1
+[issue-1]: https://github.com/susapad/software-insider/issues/1
 [gh-rules]: https://docs.github.com/es/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community
 
 ---
@@ -40,8 +54,8 @@ y asegúrase de saber sobre las
 
 ### SusaPad Software
 
-*SusaPad Software* está cubierto por la *GPL-3.0*, y sigue los siguientes
-cuatro grados de liberdad:
+*SusaPad Software Insider* está cubierto por la *GPL-3.0*, 
+y sigue los siguientes cuatro grados de liberdad:
 
 - Liberdad de ejecutar el programa para cualquier propósito.
 - Liberdad de estudiar como el programa funciona y adaptarlo a certas necesidades.
@@ -101,8 +115,9 @@ For more details about their license, [read Qt's License][qt-license].
 
 ### ¿Es este software compatíble con el *Minipad*?
 
-Si, esse software es compatible con la [versión actual del *minipad-firmware*
- (*2023.410.1*)][minipad-release], que el *SusaPad* irá usar.
+Si, esse software es compatible con la [versión legado del *minipad-firmware*
+(*commit `f62f827`*)][minipad-commit], 
+que es la utilizada por el *SusaPad Insider Edition*.
 
 ### ¿Por qué mi aplicación es tan lenta?
 
@@ -117,7 +132,7 @@ levar hasta seis segundos para completarse.
 ### Ese software es traducido?
 
 No, pero planejamos traducirlo próximamente.
-Por ahora, el *SusaPad Software* apresentase
+Por ahora, el *SusaPad Software Insider* apresentase
 disponible sólo en el portugués,
 la lenguaje nativa del proyeto.
 
@@ -129,8 +144,13 @@ y no tiene alguna relación con otros proyectos
 como *Minipad Project*, *Nuitka*, *pySerial* o *QT Company*,
 solamente con *SusaPad* en si.
 
+También, es bueno mencionar que *SusaPad Software Insider* es un fork
+del *SusaPad Software* para trabajar con la versión *Arduino* del *SusaPad*,
+el *SusaPad Insider Edition*.
+Así, este sigue las mismas normas y licencias dadas por el *SusaPad Software*.
 
-[minipad-release]: https://github.com/minipadKB/minipad-firmware/releases/tag/2023.410.1
+
+[minipad-commit]: https://github.com/minipadKB/minipad-firmware-old/commit/f62f827ce73f8c3a55bdd9106de2d631eb93e775
 
 
 ## Contributors

--- a/README.es.md
+++ b/README.es.md
@@ -130,7 +130,7 @@ que es la utilizada por el *SusaPad Insider Edition*.
 ### ¿Por qué mi aplicación es tan lenta?
 
 Esto no es la aplicación en si,
-mas la forma con que comunicamonos con el *Arduino*.
+mas la forma con que comunicamonos vía puerta serial.
 
 Infelismente, los comando somente pueden ser enviados con
 uno segundo de intervalo entre los mismos.

--- a/README.es.md
+++ b/README.es.md
@@ -6,11 +6,12 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software Insider* es el software usado para configurar 
+*SusaPad Software Insider* es el *software* usado para configurar 
 el *SusaPad Insider Edition*/[*MiniPad*][minipad].
 
-> **Note**: *SusaPad Software* hace referencia al [SusaPad Software][software],
-> el no es el mismo que *SusaPad*, cuyo es un *keypad* (hardware).
+> **Note**: *SusaPad Software* 
+> hace referencia al [*SusaPad Software*][software],
+> el no es el mismo que *SusaPad*, cuyo es un *keypad* (*hardware*).
 
 > **Note**: Este no está disponible para 
 > todas las versiones del *SusaPad*/*MiniPad*
@@ -30,7 +31,7 @@ desde que este software fue diseñado solo para el *Insider Edition*,
 cuyo usa *Arduino* en vez de *Raspberry*
 y el [antigo firmware del *MiniPad*][old-firmware] en vez del más reciente.
 
-Si tu *SusaPad*/*MiniPad* se encuentra el la más nueva versión del firmware,
+Si tu *SusaPad*/*MiniPad* se encuentra el la más nueva versión del *firmware*,
 utilice el [*SusaPad Software*][software].
 
 [old-firmware]: https://github.com/minipadKB/minipad-firmware-old
@@ -42,12 +43,12 @@ utilice el [*SusaPad Software*][software].
 
 ### Issues
 
-Puedes añadir propuestas: bugs, dudas, preguntas,
-solicitud de nuevas funcionalidades via Issues.
+Puedes añadir propuestas: *bugs*, dudas, preguntas,
+solicitud de nuevas funcionalidades via *Issues*.
 
-Por favor, leas cuidadosamiente [nosa Issue fijada][issue-1]
+Por favor, leas cuidadosamiente [nosa *Issue* fijada][issue-1]
 y asegúrase de saber sobre las
-[Pautas de la Comunidad de GitHub][gh-rules].
+[Pautas de la Comunidad de *GitHub*][gh-rules].
 
 [issue-1]: https://github.com/susapad/software-insider/issues/1
 [gh-rules]: https://docs.github.com/es/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community
@@ -120,16 +121,16 @@ For more details about their license, [read Qt's License][qt-license].
 
 ## FAQ
 
-### ¿Es este software compatíble con el *Minipad*?
+### ¿Es este *software* compatíble con el *Minipad*?
 
-Si, esse software es compatible con la [versión legado del *minipad-firmware*
+Si, esse *software* es compatible con la [versión legado del *minipad-firmware*
 (*commit `f62f827`*)][minipad-commit], 
 que es la utilizada por el *SusaPad Insider Edition*.
 
 ### ¿Por qué mi aplicación es tan lenta?
 
 Esto no es la aplicación en si,
-mas la forma con que comunicamonos con el arduino.
+mas la forma con que comunicamonos con el *Arduino*.
 
 Infelismente, los comando somente pueden ser enviados con
 uno segundo de intervalo entre los mismos.

--- a/README.es.md
+++ b/README.es.md
@@ -6,7 +6,8 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software* es el software usado para configurar *SusaPad*/[*MiniPad*][minipad].
+*SusaPad Software Insider* es el software usado para configurar 
+el *SusaPad Insider Edition*/[*MiniPad*][minipad].
 
 > **Note**: *SusaPad Software* hace referencia al [SusaPad Software][software],
 > el no es el mismo que *SusaPad*, cuyo es un *keypad* (hardware).
@@ -28,6 +29,12 @@ Este no está disponible para todas las versiones del *SusaPad*
 desde que este software fue diseñado solo para el *Insider Edition*,
 cuyo usa *Arduino* en vez de *Raspberry*
 y el [antigo firmware del *MiniPad*][old-firmware] en vez del más reciente.
+
+Si tu *SusaPad*/*MiniPad* se encuentra el la más nueva versión del firmware,
+utilice el [*SusaPad Software*][software].
+
+[old-firmware]: https://github.com/minipadKB/minipad-firmware-old
+[software]: https://github.com/susapad/software
 
 ### Instalación
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,34 @@
 
 
-# SusaPad Software
+# SusaPad Software Insider
 
 > [[Português](./README.pt-br.md)] | [[Español](./README.es.md)]
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software* is the software used to configure *SusaPad*/[*MiniPad*][minipad].
+*SusaPad Software* is the software used to configure 
+*SusaPad*/[*MiniPad*][minipad].
 
-> **Note**: *SusaPad Software* refers to this project itself,
+> **Note**: *SusaPad Software* refers to [SusaPad Software][software],
 > but it's not the same as *SusaPad*, which is just a *keypad* (hardware).
+> *SusaPad Software Insider* refers to this project itself.
+
+> **Note**: It's not available to all SusaPad/MiniPad's version. 
+> Please read [Compatibility Section](#compatibility) to more information.
 
 [minipad]: https://github.com/minipadKB
+[software]: https://github.com/susapad/software
 
 ## User Guide
+
+### Compatibility
+
+It's not available to all *SusaPad*'s version 
+since it's for *Insider edition* only,
+which uses *Arduino* instead of *Raspberry* 
+and the [old MiniPad's firmware][old-firmware] instead of the latest.
+
+[old-firmware]: https://github.com/minipadKB/minipad-firmware-old
 
 ### Installation
 
@@ -28,7 +43,7 @@ Please, carefully read [our pinned Issue][issue-1]
 and make sure that you know about
 [Github's Community Guideline][gh-rules].
 
-[issue-1]: https://github.com/susapad/software/issues/1
+[issue-1]: https://github.com/susapad/software-insider/issues/1
 [gh-rules]: https://docs.github.com/en/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community
 
 ---
@@ -36,9 +51,9 @@ and make sure that you know about
 
 ## Licenses
 
-### SusaPad Software
+### SusaPad Software Insider
 
-*SusaPad Software* is under *GPL-3.0*, and it follows the following
+*SusaPad Software Insider* is under *GPL-3.0*, and it follows the following
 four degrees of freedom:
 
 - Freedom to run the program for any purpose.
@@ -99,9 +114,9 @@ For more details about their license, [read Qt's License][qt-license].
 
 ### Is it compatible with *Minipad*?
 
-Yes, it's compatible with the [current *minipad-firmware*'s
-version (*2023.410.1*)][minipad-release],
-which *SusaPad* will use.
+Yes, it's compatible with the [old *minipad-firmware*'s
+version (*commit `f62f827`*)][minipad-commit],
+used by *SusaPad Insider*.
 
 
 ### Why my application is so slow?
@@ -118,7 +133,7 @@ may take up to six seconds to complete.
 ### Is this software translated?
 
 No, it isn't. But we plan to translate it soon.
-For now *SusaPad Software* is just available to Portuguese,
+For now *SusaPad Software Insider* is just available to Portuguese,
 the native language of this project.
 
 
@@ -129,8 +144,13 @@ and has no relationship with other projects
 such as *Minipad Project*, *Nuitka*, *pySerial* or *QT Company*,
 but it has relationship with *SusaPad* itself.
 
+Also, worth mentioning that *SusaPad Software Insider* is a fork
+of *SusaPad Software* to work with the *Arduino* version of *SusaPad*,
+the *SusaPad Insider*.
+So, it follows the same rules and licences given by *SusaPad Software*.
 
-[minipad-release]: https://github.com/minipadKB/minipad-firmware/releases/tag/2023.410.1
+
+[minipad-commit]: https://github.com/minipadKB/minipad-firmware-old/commit/f62f827ce73f8c3a55bdd9106de2d631eb93e775
 
 
 ## Contributors
@@ -141,7 +161,7 @@ but it has relationship with *SusaPad* itself.
 - Legacy application by: [Luiz Fernando][batatinho]
 
 It's good to mention Luiz Fernando who was responsible for creating
-the first functional version of *SusaPad* in *Kivy*.
+the first functional version of *SusaPad Software* in *Kivy*.
 
 
 [sousa]: https://github.com/sousaone1

--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 > but it's not the same as *SusaPad*, which is just a *keypad* (hardware).
 > *SusaPad Software Insider* refers to this project itself.
 
-> **Note**: It's not available to all SusaPad/MiniPad's version. 
+> **Note**: It's not available to all *SusaPad*/*MiniPad*'s version.
+>
 > Please read [Compatibility Section](#compatibility) to more information.
 
 [minipad]: https://github.com/minipadKB
@@ -116,7 +117,7 @@ For more details about their license, [read Qt's License][qt-license].
 
 Yes, it's compatible with the [old *minipad-firmware*'s
 version (*commit `f62f827`*)][minipad-commit],
-used by *SusaPad Insider*.
+used by *SusaPad Insider Edition*.
 
 
 ### Why my application is so slow?
@@ -146,7 +147,7 @@ but it has relationship with *SusaPad* itself.
 
 Also, worth mentioning that *SusaPad Software Insider* is a fork
 of *SusaPad Software* to work with the *Arduino* version of *SusaPad*,
-the *SusaPad Insider*.
+the *SusaPad Insider Edition*.
 So, it follows the same rules and licences given by *SusaPad Software*.
 
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ used by *SusaPad Insider Edition*.
 ### Why my application is so slow?
 
 It's not the application itself,
-but the way it comunicate with arduino.
+but the way it comunicate via serial port.
 
 Unfortunately, the commands can only be sent with
 one second of interval between.

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software* is the software used to configure 
-*SusaPad*/[*MiniPad*][minipad].
+*SusaPad Software Insider* is the software used to configure 
+*SusaPad Insider Edition*/[*MiniPad*][minipad].
 
 > **Note**: *SusaPad Software* refers to [SusaPad Software][software],
 > but it's not the same as *SusaPad*, which is just a *keypad* (hardware).
@@ -29,7 +29,11 @@ since it's for *Insider edition* only,
 which uses *Arduino* instead of *Raspberry* 
 and the [old MiniPad's firmware][old-firmware] instead of the latest.
 
+If your *SusaPad*/*MiniPad* is at the latest firmware's version,
+so use the [*SusaPad Software*][software].
+
 [old-firmware]: https://github.com/minipadKB/minipad-firmware-old
+[software]: https://github.com/susapad/software
 
 ### Installation
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -8,12 +8,28 @@
 
 *SusaPad Software* is the software used to configure *SusaPad*/[*MiniPad*][minipad].
 
-> **Note**: *SusaPad Software* refere-se a esse projeto em si,
+> **Note**: *SusaPad Software* refere-se ao [SusaPad Software][software],
 > mas não é o mesmo que o *SusaPad*, o qual é um *keypad* (hardware).
 
+> **Note**: Este não está disponível para 
+> todas as versões do *SusaPad*/*Minipad*.
+>
+> Por favor, leia a [Secção de Compatibilidade](#compatibilidade) 
+> para mais informações.
+
 [minipad]: https://github.com/minipadKB
+[software]: https://github.com/susapad/software
 
 ## Guia do Usuário
+
+### Compatibilidade
+
+Este não está disponível para todas as versões do *SusaPad*
+desde que este software foi desenhado para o *Insider Edition* apenas,
+que usa *Arduino* ao invés do *Raspberry*
+e o [antigo firmware do MiniPad][old-firmware] ao invés do mais recente.
+
+[old-firmware]: https://github.com/minipadKB/minipad-firmware-old
 
 ### Instalação
 
@@ -29,7 +45,7 @@ Por favor, leia atentamente [nossa proposta fixada][issue-1]
 e tenha certeza de estar ciente das
 [Diretrizes da Comunidade do GitHub][gh-rules].
 
-[issue-1]: https://github.com/susapad/software/issues/1
+[issue-1]: https://github.com/susapad/software-insider/issues/1
 [gh-rules]: https://docs.github.com/pt/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community
 
 ---
@@ -41,7 +57,7 @@ e tenha certeza de estar ciente das
 
 ### SusaPad Software
 
-*SusaPad Software* é coberto por *GPL-3.0*, e segue os seguintes
+*SusaPad Software Insider* é coberto por *GPL-3.0*, e segue os seguintes
 quatro degraus de liberdade:
 
 - Liberdade de rodar o programa para quaisquer propósito.
@@ -100,11 +116,11 @@ For more details about their license, [read Qt's License][qt-license].
 
 ## FAQ
 
-### Isto é compatível com *Minipad*?
+### Este é compatível com *Minipad*?
 
-Sim, isto é compatível com a [versão atual do *minipad-firmware*
-(*2023.410.1*)][minipad-release],
-o qual *SusaPad* utilizará.
+Sim, o mesmo é compatível com a [versão legado do *minipad-firmware*,
+(*commit `f62f827`*)][minipad-commit], 
+usado pelo *SusaPad Insider Edition*.
 
 
 ### Por que minha aplicação é tão lenta?
@@ -121,7 +137,7 @@ podem levar até seis segundos para serem completadas.
 ### Esse software é traduzido?
 
 Não, mas planejamos traduzí-lo em breve.
-Por enquanto, o *SusaPad Software* se apresenta
+Por enquanto, o *SusaPad Software Insider* se apresenta
 disponível apenas em português,
 a linguagem nativa desse projeto.
 
@@ -133,7 +149,13 @@ e não tem quaisquer relações com outros projetos
 como *Minipad Project*, *Nuitka*, *pySerial* ou *QT Company*,
 apenas com o *SusaPad* em si.
 
-[minipad-release]: https://github.com/minipadKB/minipad-firmware/releases/tag/2023.410.1
+Também, vale mencionar que *SusaPad Software Insider* é um fork
+do *SusaPad Software* para funcionar com a versão *Arduino* do *SusaPad*,
+o *SusaPad Insider*.
+Logo, este segue as mesmas regras e licenças dadas pelo *SusaPad Software*.
+
+
+[minipad-commit]: https://github.com/minipadKB/minipad-firmware-old/commit/f62f827ce73f8c3a55bdd9106de2d631eb93e775
 
 
 ## Contribuidores

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,13 +6,13 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software Insider* é o software usado para configurar 
+*SusaPad Software Insider* é o *software* usado para configurar 
 o *SusaPad Insider Edition*/[*MiniPad*][minipad].
 
-> **Note**: *SusaPad Software* refere-se ao [SusaPad Software][software],
-> mas não é o mesmo que o *SusaPad*, o qual é um *keypad* (hardware).
+> **Note**: *SusaPad Software* refere-se ao [*SusaPad Software*][software],
+> mas não é o mesmo que o *SusaPad*, o qual é um *keypad* (*hardware*).
 
-> **Note**: Este software não está disponível para 
+> **Note**: Este *software* não está disponível para 
 > todas as versões do *SusaPad*/*Minipad*.
 >
 > Por favor, leia a [Secção de Compatibilidade](#compatibilidade) 
@@ -43,12 +43,12 @@ utilize o [*SusaPad Software*][software].
 ### Propostas
 
 Você poderá adicionar propostas:
-bugs, dúvidas, perguntas, requisições de recursos,
-via Issues.
+*bugs*, dúvidas, perguntas, requisições de recursos,
+via *Issues*.
 
 Por favor, leia atentamente [nossa proposta fixada][issue-1]
 e tenha certeza de estar ciente das
-[Diretrizes da Comunidade do GitHub][gh-rules].
+[Diretrizes da Comunidade do *GitHub*][gh-rules].
 
 [issue-1]: https://github.com/susapad/software-insider/issues/1
 [gh-rules]: https://docs.github.com/pt/site-policy/github-terms/github-community-guidelines#maintaining-a-strong-community

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,7 +6,7 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software Insider* is the software used to configure 
+*SusaPad Software Insider* é o software usado para configurar 
 o *SusaPad Insider Edition*/[*MiniPad*][minipad].
 
 > **Note**: *SusaPad Software* refere-se ao [SusaPad Software][software],

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -6,12 +6,13 @@
 
 ![gpl-3.0](./susapad/media/gplv3-with-text-136x68.png)
 
-*SusaPad Software* is the software used to configure *SusaPad*/[*MiniPad*][minipad].
+*SusaPad Software Insider* is the software used to configure 
+o *SusaPad Insider Edition*/[*MiniPad*][minipad].
 
 > **Note**: *SusaPad Software* refere-se ao [SusaPad Software][software],
 > mas não é o mesmo que o *SusaPad*, o qual é um *keypad* (hardware).
 
-> **Note**: Este não está disponível para 
+> **Note**: Este software não está disponível para 
 > todas as versões do *SusaPad*/*Minipad*.
 >
 > Por favor, leia a [Secção de Compatibilidade](#compatibilidade) 
@@ -29,7 +30,11 @@ desde que este software foi desenhado para o *Insider Edition* apenas,
 que usa *Arduino* ao invés do *Raspberry*
 e o [antigo firmware do MiniPad][old-firmware] ao invés do mais recente.
 
+Se o seu *SusaPad*/*MiniPad* se encontra na versão mais nova do firmware,
+utilize o [*SusaPad Software*][software].
+
 [old-firmware]: https://github.com/minipadKB/minipad-firmware-old
+[software]: https://github.com/susapad/software
 
 ### Instalação
 

--- a/README.pt-br.md
+++ b/README.pt-br.md
@@ -131,7 +131,7 @@ usado pelo *SusaPad Insider Edition*.
 ### Por que minha aplicação é tão lenta?
 
 Isso não é a aplicação em si,
-mas a forma como nos comunicamos com o arduino.
+mas a forma como nos comunicamos via porta serial.
 
 Infelizmente, os comandos só podem ser enviado com
 um segundo de intervalo entre eles.


### PR DESCRIPTION
This first PR changes the README to differentiate this forked project from [SusaPad Software][software].

While *SusaPad Software* works for the default version of SusaPad that uses _Raspberry_ and the new [MiniPad's firmware][firmware], this project was made to work with _Arduino_ version of *SusaPad*, the *SusaPad Insider Edition* that uses the [legacy *MiniPad*'s firmware][old-firmware]

[software]: https://github.com/susapad/software
[firmware]: https://github.com/minipadKB/minipad-firmware
[old-firmware]: https://github.com/minipadKB/minipad-firmware-old/